### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [ "preview" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/BrewSleeDerby/scoreboard/security/code-scanning/1](https://github.com/BrewSleeDerby/scoreboard/security/code-scanning/1)

Add an explicit `permissions` block to the workflow YAML so the `GITHUB_TOKEN` is constrained.  
Best fix here: define workflow-level permissions right after the `on:` trigger (or after `name:`/`on:` section) with the minimum needed scope:

- `contents: read`

This preserves existing functionality (checkout/build/test) while documenting and enforcing least privilege for all jobs in this workflow unless overridden.

**File to edit:** `.github/workflows/node.js.yml`  
**Change location:** insert a new top-level `permissions:` block between the `on:` block and `jobs:` block.  
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
